### PR TITLE
add catalog-info.yaml config file and codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ResultadosDigitais/devtools

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: paddy-elixir
+  annotations:
+    github.com/project-slug: ResultadosDigitais/paddy-elixir
+spec:
+  type: library
+  lifecycle: production
+  owner: devtools


### PR DESCRIPTION
Contexto

Estamos mapeando os componentes do plataform para dentro do Backstage e por isso precisamos deste arquivo yaml no mesmo diretório do componente para que ele seja refletido no Backstage.

É possível consultar mais detalhes deste mapeamento aqui: https://github.com/ResultadosDigitais/designdoc/blob/master/enablers/devtools/fonte-da-verdade-artefatos.md