### PR TITLE
Allow passing project_id and topic_id arguments in publish method

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ config :paddy,
   topic_id: "some-topic"
 ```
 
+- Or if you prefer, you can call the publish method directly, passing the project_id and topic_id parameters as arguments:
+
+```elixir
+Paddy.publish(params, project_id: "custom_project_id", topic_id: "custom_topic_id")
+```
+
 ### Using
 
 > The lib is only responsible to receive the data and publish it to the previously set project_id/topic_id, the list IS NOT responsible to transform and mount the format, this step must be done by the application that will use `paddy`.

--- a/lib/paddy.ex
+++ b/lib/paddy.ex
@@ -46,8 +46,8 @@ defmodule Paddy do
     topic_id = Keyword.get(args, :topic_id, @topic_id)
     client_email = Keyword.get(args, :client_email)
 
-    encoded_data = encode_data(data)
-    message = %Model.PubsubMessage{data: encoded_data}
+    #encoded_data = encode_data(data)
+    message = %Model.PubsubMessage{data: data}
     data_request = %Model.PublishRequest{messages: [message]}
 
     Projects.pubsub_projects_topics_publish(get_connection(client_email), project_id, topic_id,

--- a/lib/paddy.ex
+++ b/lib/paddy.ex
@@ -46,8 +46,8 @@ defmodule Paddy do
     topic_id = Keyword.get(args, :topic_id, @topic_id)
     client_email = Keyword.get(args, :client_email)
 
-    #encoded_data = encode_data(data)
-    message = %Model.PubsubMessage{data: data}
+    encoded_data = encode_data(data)
+    message = %Model.PubsubMessage{data: encoded_data}
     data_request = %Model.PublishRequest{messages: [message]}
 
     Projects.pubsub_projects_topics_publish(get_connection(client_email), project_id, topic_id,
@@ -55,10 +55,10 @@ defmodule Paddy do
     )
   end
 
-  # defp encode_data(data) do
-  #   {:ok, encoded_data} = Poison.encode(data)
-  #   Base.encode64(encoded_data)
-  # end
+  defp encode_data(data) do
+    # {:ok, encoded_data} = Poison.encode(data)
+    Base.encode64(data)
+  end
 
   ### Disclaimer!
   #

--- a/lib/paddy.ex
+++ b/lib/paddy.ex
@@ -69,7 +69,7 @@ defmodule Paddy do
   #
   # Link for the doc: https://github.com/peburrows/goth/blob/master/lib/goth/token.ex#L3
   defp get_connection(client_email) do
-    {:ok, token} = Goth.Token.for_scope("https://www.googleapis.com/auth/pubsub", client_email)
+    {:ok, token} = Goth.Token.for_scope({client_email, "https://www.googleapis.com/auth/pubsub"})
 
     token
     |> Map.get(:token)

--- a/lib/paddy.ex
+++ b/lib/paddy.ex
@@ -45,8 +45,9 @@ defmodule Paddy do
     project_id = Keyword.get(args, :project_id, @project_id)
     topic_id = Keyword.get(args, :topic_id, @topic_id)
     client_email = Keyword.get(args, :client_email)
+    version = Keyword.get(args, :version, :v1)
 
-    encoded_data = encode_data(data)
+    encoded_data = encode_data(data, version)
     message = %Model.PubsubMessage{data: encoded_data}
     data_request = %Model.PublishRequest{messages: [message]}
 
@@ -55,10 +56,18 @@ defmodule Paddy do
     )
   end
 
-  defp encode_data(data) do
-    # {:ok, encoded_data} = Poison.encode(data)
-    Base.encode64(data)
+  defp encode_data(data, version) do
+    case version do
+      :v1 ->
+        {:ok, encoded_data} = Poison.encode(data)
+        Base.encode64(encoded_data)
+      :v2 ->
+        Base.encode64(data)
+      _ ->
+        raise ArgumentError, "Unsupported version: #{inspect(version)}"
+    end
   end
+  
 
   ### Disclaimer!
   #

--- a/lib/paddy.ex
+++ b/lib/paddy.ex
@@ -55,10 +55,10 @@ defmodule Paddy do
     )
   end
 
-  defp encode_data(data) do
-    {:ok, encoded_data} = Poison.encode(data)
-    Base.encode64(encoded_data)
-  end
+  # defp encode_data(data) do
+  #   {:ok, encoded_data} = Poison.encode(data)
+  #   Base.encode64(encoded_data)
+  # end
 
   ### Disclaimer!
   #

--- a/lib/paddy.ex
+++ b/lib/paddy.ex
@@ -44,11 +44,13 @@ defmodule Paddy do
   def publish(data, args \\ []) do
     project_id = Keyword.get(args, :project_id, @project_id)
     topic_id = Keyword.get(args, :topic_id, @topic_id)
+    client_email = Keyword.get(args, :client_email)
+
     encoded_data = encode_data(data)
     message = %Model.PubsubMessage{data: encoded_data}
     data_request = %Model.PublishRequest{messages: [message]}
 
-    Projects.pubsub_projects_topics_publish(get_connection(), project_id, topic_id,
+    Projects.pubsub_projects_topics_publish(get_connection(client_email), project_id, topic_id,
       body: data_request
     )
   end
@@ -66,8 +68,8 @@ defmodule Paddy do
   # We are currently using the lib in version 1.0.1 ~ 27/03/2019.
   #
   # Link for the doc: https://github.com/peburrows/goth/blob/master/lib/goth/token.ex#L3
-  defp get_connection do
-    {:ok, token} = Goth.Token.for_scope("https://www.googleapis.com/auth/pubsub")
+  defp get_connection(client_email) do
+    {:ok, token} = Goth.Token.for_scope("https://www.googleapis.com/auth/pubsub", client_email)
 
     token
     |> Map.get(:token)

--- a/lib/paddy.ex
+++ b/lib/paddy.ex
@@ -41,12 +41,14 @@ defmodule Paddy do
       iex> {:ok,%GoogleApi.PubSub.V1.Model.PublishResponse{messageIds: ["422315144637561"]}}
   """
 
-  def publish(data) do
+  def publish(data, args \\ []) do
+    project_id = Keyword.get(args, :project_id, @project_id)
+    topic_id = Keyword.get(args, :topic_id, @topic_id)
     encoded_data = encode_data(data)
     message = %Model.PubsubMessage{data: encoded_data}
     data_request = %Model.PublishRequest{messages: [message]}
 
-    Projects.pubsub_projects_topics_publish(get_connection(), @project_id, @topic_id,
+    Projects.pubsub_projects_topics_publish(get_connection(), project_id, topic_id,
       body: data_request
     )
   end

--- a/test/paddy_test.exs
+++ b/test/paddy_test.exs
@@ -20,11 +20,16 @@ defmodule PaddyTest do
         event_timestamp: event_timestamp,
         payload: payload
       }
-      with_mock Projects,
-        pubsub_projects_topics_publish: fn _connection, _project_id, _topic_id, _params -> :ok end do
+
+      with_mocks [
+        {Projects, [], pubsub_projects_topics_publish: fn _connection, _project_id, _topic_id, _params -> :ok end},
+        {Goth.Token, [], for_scope: fn _ -> {:ok, %{token: "mocked_token"}} end}
+      ] do
         Paddy.publish(params)
 
-        assert called(Projects.pubsub_projects_topics_publish(:_, :_, :_, :_))
+        assert called(
+          Projects.pubsub_projects_topics_publish(:_, :_, :_, :_)
+        )
       end
     end
 
@@ -42,11 +47,16 @@ defmodule PaddyTest do
         event_timestamp: event_timestamp,
         payload: payload
       }
-      with_mock Projects,
-        pubsub_projects_topics_publish: fn _connection, _project_id, _topic_id, _params -> :ok end do
-        Paddy.publish(params, project_id: "custom_project_id", topic_id: "custom_topic_id")
 
-        assert called(Projects.pubsub_projects_topics_publish(:_, :_, :_, :_))
+      with_mocks [
+        {Projects, [], pubsub_projects_topics_publish: fn _connection, _project_id, _topic_id, _params -> :ok end},
+        {Goth.Token, [], for_scope: fn _ -> {:ok, %{token: "mocked_token"}} end}
+      ] do
+        Paddy.publish(params, project_id: "custom_project_id", topic_id: "custom_topic_id", client_email: "custom_email")
+
+        assert called(
+          Projects.pubsub_projects_topics_publish(:_, :_, :_, :_)
+        )
       end
     end
   end

--- a/test/paddy_test.exs
+++ b/test/paddy_test.exs
@@ -20,10 +20,31 @@ defmodule PaddyTest do
         event_timestamp: event_timestamp,
         payload: payload
       }
-
       with_mock Projects,
         pubsub_projects_topics_publish: fn _connection, _project_id, _topic_id, _params -> :ok end do
         Paddy.publish(params)
+
+        assert called(Projects.pubsub_projects_topics_publish(:_, :_, :_, :_))
+      end
+    end
+
+    test "publish with custom project_id and topic_id" do
+      version = :v1
+      company_id = :rand.uniform(100)
+      event_type = "foobar_event"
+      payload = %{id: 1, name: "foobar"}
+      event_timestamp = ~N[2018-08-01 22:15:07]
+
+      params = %{
+        version: version,
+        company_id: company_id,
+        event_type: event_type,
+        event_timestamp: event_timestamp,
+        payload: payload
+      }
+      with_mock Projects,
+        pubsub_projects_topics_publish: fn _connection, _project_id, _topic_id, _params -> :ok end do
+        Paddy.publish(params, project_id: "custom_project_id", topic_id: "custom_topic_id")
 
         assert called(Projects.pubsub_projects_topics_publish(:_, :_, :_, :_))
       end

--- a/test/paddy_test.exs
+++ b/test/paddy_test.exs
@@ -67,6 +67,6 @@ defmodule PaddyTest do
       ] do
         Paddy.publish(params, project_id: "custom_project_id", topic_id: "custom_topic_id", client_email: "custom_client_email")
       end      
-    end    
+    end
   end
 end


### PR DESCRIPTION
Precisamos ajustar o projeto [paddy-elixir](https://github.com/ResultadosDigitais/paddy-elixir) , que é dependência do [partnership](https://github.com/ResultadosDigitais/partnership), para que seja possível receber os parâmetros de configuração do Paddy, como o project_id e topic_id, isso irá nos permitir publicar eventos nos data-lakes v1 e v2 de forma dinâmica para o project_id/topic_id previamente definido.