### PR TITLE
Undo changes and only allowing data-lake v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,6 @@ config :paddy,
   topic_id: "some-topic"
 ```
 
-- Or if you prefer, you can call the publish method directly, passing the project_id and topic_id parameters as arguments:
-
-```elixir
-Paddy.publish(params, project_id: "custom_project_id", topic_id: "custom_topic_id")
-```
-
 ### Using
 
 > The lib is only responsible to receive the data and publish it to the previously set project_id/topic_id, the list IS NOT responsible to transform and mount the format, this step must be done by the application that will use `paddy`.

--- a/lib/paddy.ex
+++ b/lib/paddy.ex
@@ -42,7 +42,7 @@ defmodule Paddy do
   """
 
   def publish(data) do
-    encoded_data = encode_data(data)
+    encoded_data = Base.encode64(data)
     message = %Model.PubsubMessage{data: encoded_data}
     data_request = %Model.PublishRequest{messages: [message]}
 
@@ -50,13 +50,6 @@ defmodule Paddy do
       body: data_request
     )
   end
-
-  defp encode_data(data) do
-    data
-    |> Jason.encode!() # Converte o mapa para uma string JSON.
-    |> Base.encode64() # Codifica a string em Base64.
-  end
-  
 
   ### Disclaimer!
   #

--- a/lib/paddy.ex
+++ b/lib/paddy.ex
@@ -41,31 +41,20 @@ defmodule Paddy do
       iex> {:ok,%GoogleApi.PubSub.V1.Model.PublishResponse{messageIds: ["422315144637561"]}}
   """
 
-  def publish(data, args \\ []) do
-    project_id = Keyword.get(args, :project_id, @project_id)
-    topic_id = Keyword.get(args, :topic_id, @topic_id)
-    client_email = Keyword.get(args, :client_email)
-    version = Keyword.get(args, :version, :v1)
-
-    encoded_data = encode_data(data, version)
+  def publish(data) do
+    encoded_data = encode_data(data)
     message = %Model.PubsubMessage{data: encoded_data}
     data_request = %Model.PublishRequest{messages: [message]}
 
-    Projects.pubsub_projects_topics_publish(get_connection(client_email), project_id, topic_id,
+    Projects.pubsub_projects_topics_publish(get_connection(), @project_id, @topic_id,
       body: data_request
     )
   end
 
-  defp encode_data(data, version) do
-    case version do
-      :v1 ->
-        {:ok, encoded_data} = Poison.encode(data)
-        Base.encode64(encoded_data)
-      :v2 ->
-        Base.encode64(data)
-      _ ->
-        raise ArgumentError, "Unsupported version: #{inspect(version)}"
-    end
+  defp encode_data(data) do
+    data
+    |> Jason.encode!() # Converte o mapa para uma string JSON.
+    |> Base.encode64() # Codifica a string em Base64.
   end
   
 
@@ -77,8 +66,8 @@ defmodule Paddy do
   # We are currently using the lib in version 1.0.1 ~ 27/03/2019.
   #
   # Link for the doc: https://github.com/peburrows/goth/blob/master/lib/goth/token.ex#L3
-  defp get_connection(client_email) do
-    {:ok, token} = Goth.Token.for_scope({client_email, "https://www.googleapis.com/auth/pubsub"})
+  defp get_connection() do
+    {:ok, token} = Goth.Token.for_scope("https://www.googleapis.com/auth/pubsub")
 
     token
     |> Map.get(:token)

--- a/test/paddy_test.exs
+++ b/test/paddy_test.exs
@@ -21,52 +21,12 @@ defmodule PaddyTest do
         payload: payload
       }
 
-      with_mocks [
-        {Projects, [], pubsub_projects_topics_publish: fn _connection, project_id, topic_id, options ->
-          publish_request = Keyword.get(options, :body)
-
-          assert %GoogleApi.PubSub.V1.Model.PublishRequest{
-                    messages: [%GoogleApi.PubSub.V1.Model.PubsubMessage{data: _}]
-                  } = publish_request
-          :ok
-        end},
-        {Goth.Token, [], for_scope: fn _ -> {:ok, %{token: "mocked_token"}} end}
-      ] do
+      with_mock Projects,
+        pubsub_projects_topics_publish: fn _connection, _project_id, _topic_id, _params -> :ok end do
         Paddy.publish(params)
+
+        assert called(Projects.pubsub_projects_topics_publish(:_, :_, :_, :_))
       end
-    end
-
-    test "publish with custom project_id and topic_id" do
-      version = :v1
-      company_id = :rand.uniform(100)
-      event_type = "foobar_event"
-      payload = %{id: 1, name: "foobar"}
-      event_timestamp = ~N[2018-08-01 22:15:07]
-
-      params = %{
-        version: version,
-        company_id: company_id,
-        event_type: event_type,
-        event_timestamp: event_timestamp,
-        payload: payload
-      }
-
-      with_mocks [
-        {Projects, [], pubsub_projects_topics_publish: fn _connection, project_id, topic_id, options ->
-          assert project_id == "custom_project_id"
-          assert topic_id == "custom_topic_id"
-
-          publish_request = Keyword.get(options, :body)
-
-          assert %GoogleApi.PubSub.V1.Model.PublishRequest{
-                    messages: [%GoogleApi.PubSub.V1.Model.PubsubMessage{data: _}]
-                  } = publish_request
-          :ok
-        end},
-        {Goth.Token, [], for_scope: fn _ -> {:ok, %{token: "mocked_token"}} end}
-      ] do
-        Paddy.publish(params, project_id: "custom_project_id", topic_id: "custom_topic_id", client_email: "custom_client_email")
-      end      
     end
   end
 end

--- a/test/paddy_test.exs
+++ b/test/paddy_test.exs
@@ -23,7 +23,7 @@ defmodule PaddyTest do
 
       with_mock Projects,
         pubsub_projects_topics_publish: fn _connection, _project_id, _topic_id, _params -> :ok end do
-        Paddy.publish(params)
+        Paddy.publish(Jason.encode!(params))
 
         assert called(Projects.pubsub_projects_topics_publish(:_, :_, :_, :_))
       end


### PR DESCRIPTION
[CARD](https://rdstation.atlassian.net/browse/BILL-1431) Remover envio de eventos para data-lake v1 [paddy-elixir]

Remover os ajustes feitos na lib paddy-elixir que foram feitos para suportar o envio ao data-lake v1 e v2.